### PR TITLE
fix(fetch-table): allow pre-defined query

### DIFF
--- a/components/table/fetchTable.tsx
+++ b/components/table/fetchTable.tsx
@@ -89,14 +89,13 @@ const FetchTable = <T extends Record<string, any>>(
   React.useEffect(() => {
     (async () => {
       // convert queryURL object into query string
-      const query =
-        '?' +
-        filterQuery +
-        '&' +
-        Object.keys(queryURL)
-          .map((queryName) => `${queryName}=${queryURL[queryName]}`)
-          .join('&');
+      const queryStart = endpoint.includes('?') ? '&' : '?';
+      const limitOffset = Object.keys(queryURL)
+        .map((queryName) => `${queryName}=${queryURL[queryName]}`)
+        .join('&');
+      const filter = filterQuery ? `&${filterQuery}` : '';
 
+      const query = queryStart + limitOffset + filter;
       await submit(undefined, query);
     })();
   }, [queryURL, filterQuery]);


### PR DESCRIPTION
this will allow fixed query set included in endpoint, for example if we set the fetchTable endpoint: `domain.com/feature?category=a` then it will combined with fetchTable offset & limit (& filters if enabled):  `domain.com/feature?category=a&offset=5&limit=5`